### PR TITLE
Relax node-sass dependency; supply default CLI-importable file for node-sass.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can use this function in node-sass or any project that depends on node-sass.
 The only thing you need to do to make this work is add the inlinerfunction to the functions option.
 
 You should initialize the inliner with a basepath where it will look for the svg files.
- 
+
 ### node-sass
 
 ```js
@@ -27,11 +27,25 @@ var inliner = require('sass-inline-svg')
 sass.render({
   data: '.logo-icon{ background: svg("logo.svg")}',
   functions: {
-    
+
     svg: inliner('./', [options])
   }
 });
+```
 
+#### node-sass CLI usage
+
+```
+node-sass --functions=node_modules/sass-inline-svg/default [other node-sass arguments]
+```
+
+This is equivalent to specifying the following:
+
+```
+functions: {
+  'svg': inliner('./', {}),
+  'inline-svg': inliner('./', {})
+}
 ```
 
 ### grunt-sass
@@ -42,25 +56,26 @@ var compass = require('sass-inline-svg')
 
 
 grunt.initConfig({
-    
+
     sass:{
-       
+
         options: {
             functions: {
-                
+
                 svg: inliner('./', [options])
             }
         },
-        ...        
+        ...
     }
 
 })
 ```
+
 ## options
 
 ### optimize (default false)
 
-`{optimize: true}` uses [svgo](https://github.com/svg/svgo) internally to optmize the svg. 
+`{optimize: true}` uses [svgo](https://github.com/svg/svgo) internally to optmize the svg.
 
 ## svg transformation
 

--- a/default.js
+++ b/default.js
@@ -1,0 +1,6 @@
+const inliner = require('./index');
+
+module.exports = {
+  'svg': inliner('./', {}),
+  'inline-svg': inliner('./', {})
+};

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "deasync": "^0.1.7",
     "dom-serializer": "^0.1.0",
     "htmlparser2": "^3.9.0",
-    "node-sass": "^3.3.3",
     "object-assign": "^4.0.1",
     "svgo": "^0.6.6"
   },
@@ -49,5 +48,8 @@
     "ghooks": "^1.0.3",
     "istanbul": "^0.4.2",
     "mocha": "^2.2.1"
+  },
+  "peerDependencies": {
+    "node-sass": ">=3.0.0 <5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "eslint": "^2.1.0",
     "ghooks": "^1.0.3",
     "istanbul": "^0.4.2",
-    "mocha": "^2.2.1"
+    "mocha": "^2.2.1",
+    "node-sass": "^3.3.3"
   },
   "peerDependencies": {
     "node-sass": ">=3.0.0 <5.0.0"


### PR DESCRIPTION
This PR has two changes:

- Change node-sass to a peer dependency instead of a hard dependency. This means that you'll use whichever version is provided by your build environment instead of bringing in your own. I ran into a problem where I had competing versions of node-sass because I was on 4.x and this function depended on 3.x.

- Provide a default.js that node-sass users can use with the CLI if they just want default options (instead of having to switch to specifying the build task with js).