### PR TITLE
Add support for URI-encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ grunt.initConfig({
 
 `{optimize: true}` uses [svgo](https://github.com/svg/svgo) internally to optmize the svg.
 
+### encodingFormat (default: uri)
+
+`base64` will encode the SVG with base64, while `uri` will do a minimal URI-encoding of the svg – `uri` is always smaller, and has good browser support as well.
+
 ## svg transformation
 
 The inliner accepts a second argument, a sass-map, that describes a css like transformation. The first keys of this map are css-selectors. Their values are also sass-maps that holds a key-value store of the svg-attribute transformation you want to apply to the corresponding selector.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ grunt.initConfig({
 
 `{optimize: true}` uses [svgo](https://github.com/svg/svgo) internally to optmize the svg.
 
-### encodingFormat (default: uri)
+### encodingFormat (default: base64)
 
 `base64` will encode the SVG with base64, while `uri` will do a minimal URI-encoding of the svg – `uri` is always smaller, and has good browser support as well.
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const svgToDataUri = require('mini-svg-data-uri');
 const svgo = new (require('svgo'));
 const optimize = deasync(optimizeAsync);
 
-const defaultOptions = {optimize: false, encodingFormat: 'uri'}
+const defaultOptions = {optimize: false, encodingFormat: 'base64'}
 
 // exports
 module.exports = inliner;

--- a/index.js
+++ b/index.js
@@ -8,10 +8,11 @@ const parse = require('htmlparser2').parseDOM;
 const selectAll = require('css-select');
 const selectOne = selectAll.selectOne;
 const serialize = require('dom-serializer');
+const svgToDataUri = require('mini-svg-data-uri');
 const svgo = new (require('svgo'));
 const optimize = deasync(optimizeAsync);
 
-const defaultOptions = {optimize: false}
+const defaultOptions = {optimize: false, encodingFormat: 'uri'}
 
 // exports
 module.exports = inliner;
@@ -38,7 +39,7 @@ function inliner(base, opts) {
       content = new Buffer(optimize(content).data);
 
 
-    return encode(content);
+    return encode(content, {encodingFormat: opts.encodingFormat});
   }
 }
 
@@ -46,11 +47,18 @@ function inliner(base, opts) {
 /**
  * encode the string
  * @param content
+ * @param opts
  * @returns {types.String}
  */
-function encode(content){
+function encode(content, opts){
 
-  return (new types.String('url("data:image/svg+xml;base64,'+content.toString('base64')+'")'));
+  if (opts.encodingFormat === 'uri') {
+	  return (new types.String('url("'+svgToDataUri(content.toString('UTF-8'))+'")'));
+  } else if (opts.encodingFormat === 'base64') {
+	  return (new types.String('url("data:image/svg+xml;base64,'+content.toString('base64')+'")'));
+  } else {
+	  throw new Error('encodingFormat ' + opts.encodingFormat + ' is not supported');
+  }
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2622,14 +2622,6 @@
         "readable-stream": "2.3.3"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2639,6 +2631,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1778,6 +1778,11 @@
         "mime-db": "1.29.0"
       }
     },
+    "mini-svg-data-uri": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.0.0.tgz",
+      "integrity": "sha512-HOLwKSwgAXyjFD9ki+d9/HPgvXmZ3boaGuhMxWqVEvyi1RnV2qM3z4QDjKQuU/rhZZVHuBMobu/Y48G3ND7J4Q=="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "deasync": "^0.1.7",
     "dom-serializer": "^0.1.0",
     "htmlparser2": "^3.9.0",
+    "mini-svg-data-uri": "^1.0.0",
     "object-assign": "^4.0.1",
     "svgo": "^0.6.6"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -3,11 +3,12 @@ const svg = require('../index.js');
 const expect = require('chai').expect;
 const fs = require('fs');
 const resolve = require('path').resolve;
+const encodeMiniUri = require('mini-svg-data-uri');
 
 
 describe('test svg inliner', function(){
 
-  it('should inline svg image', function(done){
+  it('should inline svg image as base64', function(done){
 
     sass.render({
       data: '.sass{background: svg("test.svg");}',
@@ -20,6 +21,21 @@ describe('test svg inliner', function(){
       done(err);
     });
   })
+
+  it('should inline svg image as uri', function(done){
+
+    sass.render({
+      data: '.sass{background: svg("test.svg");}',
+      functions: {svg: svg(__dirname, {encodingFormat: 'uri'})}
+    }, function(err, result){
+
+      const expectedResult = encodeMiniUri(fs.readFileSync(resolve(__dirname, 'test.svg')).toString('utf-8'));
+
+      expect(result.css.toString()).to.equal(`.sass {\n  background: url("${expectedResult}"); }\n`);
+      done(err);
+    });
+  })
+
 
   it('should apply style to svg image', function(done){
 


### PR DESCRIPTION
Closes https://github.com/haithembelhaj/sass-inline-svg/issues/6

 https://css-tricks.com/probably-dont-base64-svg/ links to another article, https://codepen.io/tigt/post/optimizing-svgs-in-data-uris, which was codified in the `mini-svg-data-uri` library.

Thoughts?

Have a great week!