### PR TITLE
only pass alpha value to fill colour if it is non-1

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,11 @@ function mapToObj(map){
         value = mapToObj(value);
         break;
       case '[object SassColor]':
-        value = 'rgba('+value.getR()+','+value.getG()+','+value.getB()+','+value.getA()+')';
+        if (value.getA() === 1) {
+          value = 'rgb('+value.getR()+','+value.getG()+','+value.getB()+')';
+        } else {
+          value = 'rgba('+value.getR()+','+value.getG()+','+value.getB()+','+value.getA()+')';
+        }
         break;
       default:
         value = value.getValue();

--- a/test/index.js
+++ b/test/index.js
@@ -44,7 +44,21 @@ describe('test svg inliner', function(){
       functions: {svg: svg(__dirname)}
     }, function(err, result){
 
-      const expectedResult = new Buffer('<svg height="210" width="400"><path fill="rgba(0,0,0,1)" d="M150 0L75 200h150z"/></svg>\n').toString('base64');
+      const expectedResult = new Buffer('<svg height="210" width="400"><path fill="rgb(0,0,0)" d="M150 0L75 200h150z"/></svg>\n').toString('base64');
+
+      expect(result.css.toString()).to.equal(`.sass {\n  background: url("data:image/svg+xml;base64,${expectedResult}"); }\n`);
+      done(err);
+    });
+  })
+
+  it('should apply alpha value if set in the colour', function(done){
+
+    sass.render({
+      data: '.sass{background: svg("path-optimized.svg", (path: (fill: rgba(0,0,0,0.5))));}',
+      functions: {svg: svg(__dirname)}
+    }, function(err, result){
+
+      const expectedResult = new Buffer('<svg height="210" width="400"><path fill="rgba(0,0,0,0.5)" d="M150 0L75 200h150z"/></svg>\n').toString('base64');
 
       expect(result.css.toString()).to.equal(`.sass {\n  background: url("data:image/svg+xml;base64,${expectedResult}"); }\n`);
       done(err);
@@ -68,11 +82,11 @@ describe('test svg inliner', function(){
   it('should optimize svg with styling', function(done){
 
     sass.render({
-      data: '.sass{background: svg("path.svg", (path: (fill: #000)))}',
+      data: '.sass{background: svg("path.svg", (path: (fill: #fff)))}',
       functions: {svg: svg(__dirname, {optimize: true})}
     }, function(err, result){
 
-      const expectedResult = new Buffer('<svg height="210" width="400"><path fill="rgba(0,0,0,1)" d="M150 0L75 200h150z"/></svg>').toString('base64');
+      const expectedResult = new Buffer('<svg height="210" width="400"><path fill="#FFF" d="M150 0L75 200h150z"/></svg>').toString('base64');
 
       expect(result.css.toString()).to.equal(`.sass {\n  background: url("data:image/svg+xml;base64,${expectedResult}"); }\n`);
       done(err);


### PR DESCRIPTION
this enables better performance by the optimiser - if an alpha value
is present SVGO will not attempt to minimise it.

in the best case, this enables `rgba(255,255,255,1)` -> `#fff`

fixes #9